### PR TITLE
remove netlify toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,0 @@
-[build]
-  publish = "public"
-  command = "yarn build"
-[build.environment]
-  YARN_VERSION = "1.21.11"
-  YARN_FLAGS = "--no-ignore-optional"


### PR DESCRIPTION
The netlify toml is causing some issues as it supercedes the netlify UI. Unless we have a specific need to lock in the versions here in the config, we should defer to the UI.