### PR TITLE
fix: create schema for frontmatter field duration

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -156,3 +156,16 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     })
   }
 }
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type MarkdownRemark implements Node {
+      frontmatter: Frontmatter
+    }
+    type Frontmatter {
+      duration: String
+    }
+  `
+  createTypes(typeDefs)
+}


### PR DESCRIPTION
  - stop breaking build from duration being inferred as non-string
Closes #247 